### PR TITLE
updating import links for shim and peer package

### DIFF
--- a/blockchain-network-on-kubernetes/artifacts/chaincode/ngo_collaboration/ngo_collaboration.go
+++ b/blockchain-network-on-kubernetes/artifacts/chaincode/ngo_collaboration/ngo_collaboration.go
@@ -35,8 +35,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	sc "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	sc "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 // Define the Smart Contract structure


### PR DESCRIPTION
The shim and peer protobuf modules are no longer vendored automatically by Fabric, so they are needed to vendor individually otherwise, they lead to the issue as depicted in the attached screenshot.
![chaincode_go_import-error](https://user-images.githubusercontent.com/48702793/131334926-a477e7ef-13d5-436d-b387-0e59beadc340.png)
